### PR TITLE
Vamp Install: Update elasticsearch.json for DC/OS 1.9, Update script

### DIFF
--- a/incubator/vamp_install/elasticsearch.json
+++ b/incubator/vamp_install/elasticsearch.json
@@ -4,11 +4,12 @@
     "cpus": 0.2,
     "mem": 1024.0,
     "container": {
-	"docker": {
-	    "image": "magneticio/elastic:2.2",
-	    "network": "HOST",
-	    "forcePullImage": true
-	}
+		"type": "DOCKER",
+		"docker": {
+			"image": "magneticio/elastic:2.2",
+			"network": "HOST",
+			"forcePullImage": true
+		}
     },
     "healthChecks": [
 	{

--- a/incubator/vamp_install/script.md
+++ b/incubator/vamp_install/script.md
@@ -22,7 +22,7 @@ az login
 Now we need a resource group in which our ACS cluster will be deployed.
 
 ```
-az group create -n rgdcosvamp -l eastus2
+az group create -n rgdcosvamp -l eastus
 ```
 
 Finally we will create the cluster:
@@ -75,6 +75,8 @@ the CLI:
 dcos marathon app add elasticsearch.json
 ```
 
+*At the time of writing, Bash on Windows was unable to connect to forwarded localhost port. In this case, the DC/OS web interface can be used to start Elastic Search. Navigate to Services -> Run a Service -> JSON Configuration and paste the contents of `elasticsearch.json`*
+
 # Deploy Vamp
 
 Finally we will deploy Vamp using DC/OS Universe, we need to configure
@@ -89,6 +91,8 @@ With this file the application itself is deployed using the DC/OS cli.
 ```
 dcos package install vamp --options vamp.json --yes
 ```
+
+*At the time of writing, Bash on Windows was unable to connect to forwarded localhost port. In this case, the DC/OS web interface can be used to start Vamp. Navigate to Universe -> Packages, search for Vamp -> Advanced Installation, and enter the Elastic Search URL in `vamp.json`*
 
 We can connect to the service using the SSH tunnel we created earlier.
 

--- a/incubator/vamp_install/script.md
+++ b/incubator/vamp_install/script.md
@@ -75,7 +75,7 @@ the CLI:
 dcos marathon app add elasticsearch.json
 ```
 
-*At the time of writing, Bash on Windows was unable to connect to forwarded localhost port. In this case, the DC/OS web interface can be used to start Elastic Search. Navigate to Services -> Run a Service -> JSON Configuration and paste the contents of `elasticsearch.json`*
+*At the time of writing, Bash on Windows was unable to connect to forwarded localhost port. In this case, the DC/OS web interface can be used to start Elastic Search. Navigate to Services -> Run a Service -> JSON Configuration and paste the contents of `elasticsearch.json`. Use Cygwin or Mingw on Windows to run in an automated flow.*
 
 # Deploy Vamp
 
@@ -92,7 +92,7 @@ With this file the application itself is deployed using the DC/OS cli.
 dcos package install vamp --options vamp.json --yes
 ```
 
-*At the time of writing, Bash on Windows was unable to connect to forwarded localhost port. In this case, the DC/OS web interface can be used to start Vamp. Navigate to Universe -> Packages, search for Vamp -> Advanced Installation, and enter the Elastic Search URL in `vamp.json`*
+*At the time of writing, Bash on Windows was unable to connect to forwarded localhost port. In this case, the DC/OS web interface can be used to start Vamp. Navigate to Universe -> Packages, search for Vamp -> Advanced Installation, and enter the Elastic Search URL in `vamp.json`. Use Cygwin or Mingw on Windows to run in an automated flow.*
 
 We can connect to the service using the SSH tunnel we created earlier.
 

--- a/incubator/vamp_install/script.md
+++ b/incubator/vamp_install/script.md
@@ -1,9 +1,9 @@
 # What is Vamp?
 
-Vamp is an open source solution that provides canary releasing and
+[Vamp](http://vamp.io) is an open source solution that provides canary releasing and
 autoscaling for microservices. It runs on Kubernetes, DC/OS and Docker
 clusters. In this tutorial/demo we will focus on installing Vamp on
-ACS with DC/OS.
+ACS with [DC/OS](https://dcos.io).
 
 # Create a Cluster
 
@@ -96,4 +96,4 @@ dcos package install vamp --options vamp.json --yes
 
 We can connect to the service using the SSH tunnel we created earlier.
 
-http://localhost/service/vamp
+[http://localhost/service/vamp](http://localhost/service/vamp)


### PR DESCRIPTION
1. Add `container -> type` value to `elasticsearch.json` to comply with DC/OS 1.9 spec
2. Change region from `useast2` to `useast` (VM availability)
3. Add note for users installing from Bash on Windows (port forwarded localhost connection refused)