### PR TITLE
making ready for simdem use

### DIFF
--- a/incubator/dcos_spark_install/demo.sh
+++ b/incubator/dcos_spark_install/demo.sh
@@ -1,0 +1,1 @@
+sudo python3 ~/projects/simdem/run.py run --path ./ --style simulate .

--- a/incubator/dcos_spark_install/prep.sh
+++ b/incubator/dcos_spark_install/prep.sh
@@ -1,0 +1,1 @@
+python3 ~/projects/simdem/run.py run --path ./ preparation

--- a/incubator/dcos_spark_install/prep.sh
+++ b/incubator/dcos_spark_install/prep.sh
@@ -1,1 +1,1 @@
-python3 ~/projects/simdem/run.py run --path ./ preparation
+sudo python3 ~/projects/simdem/run.py run --path ./ preparation

--- a/incubator/dcos_spark_install/preparation/script.md
+++ b/incubator/dcos_spark_install/preparation/script.md
@@ -2,8 +2,20 @@
 
 We will use the Azure CLI 2.0 to quickly create an Azure Container
 Services cluster. Ensure you have the Azure CLI installed and have
-logged in using the `az login` command..
+logged in using the `az login` command.
 
+We first need to set a few environment variables we will use later:
+
+```
+RESOURCE_GROUP=acs-spark-demo
+SERVICE_NAME=acs-dcos-spark
+DNS_NAME_PREFIX=acs-dcos-spark
+REGION=eastus
+```
+
+```
+echo region is $REGION
+```
 
 Next, we will create a resource group for the ACS cluster to be deployed.
 
@@ -37,6 +49,7 @@ ssh -fNL 80:localhost:80 -p 2200 azureuser@acs-dcos-spark-dnsmgmt.eastus.cloudap
 Now we tell the DC/OS CLI to use this tunnel to communicate with the cluster.
 
 ```
+pip install virtualenv
 dcos config set core.dcos_url http://localhost
 ```
 

--- a/incubator/dcos_spark_install/preparation/script.md
+++ b/incubator/dcos_spark_install/preparation/script.md
@@ -35,6 +35,7 @@ In order to manage this instance of ACS we will need the DC/OS cli,
 fortunately the Azure CLI makes it easy to install it.
 
 ```
+pip install virtualenv
 az acs dcos install-cli
 ```
 
@@ -49,7 +50,6 @@ ssh -fNL 80:localhost:80 -p 2200 azureuser@acs-dcos-spark-dnsmgmt.eastus.cloudap
 Now we tell the DC/OS CLI to use this tunnel to communicate with the cluster.
 
 ```
-pip install virtualenv
 dcos config set core.dcos_url http://localhost
 ```
 

--- a/incubator/dcos_spark_install/preparation/script.md
+++ b/incubator/dcos_spark_install/preparation/script.md
@@ -1,0 +1,42 @@
+# Creating a Cluster
+
+We will use the Azure CLI 2.0 to quickly create an Azure Container
+Services cluster. Ensure you have the Azure CLI installed and have
+logged in using the `az login` command..
+
+
+Next, we will create a resource group for the ACS cluster to be deployed.
+
+```
+az group create -n acs-dcos-spark-demo -l eastus
+```
+
+Now, we can create the cluster.
+
+```
+az acs create -n acs-dcos-spark-cluster -g acs-dcos-spark-demo -d acs-dcos-spark-dns --generate-ssh-keys
+```
+
+## Install the DC/OS CLI
+
+In order to manage this instance of ACS we will need the DC/OS cli,
+fortunately the Azure CLI makes it easy to install it.
+
+```
+az acs dcos install-cli
+```
+
+## Connect to the cluster
+
+To connect to the DC/OS masters in ACS we need to open an SSH tunnel:
+
+```
+ssh -fNL 80:localhost:80 -p 2200 azureuser@acs-dcos-spark-dnsmgmt.eastus.cloudapp.azure.com -i ~/.ssh/id_rsa
+```
+
+Now we tell the DC/OS CLI to use this tunnel to communicate with the cluster.
+
+```
+dcos config set core.dcos_url http://localhost
+```
+

--- a/incubator/dcos_spark_install/script.md
+++ b/incubator/dcos_spark_install/script.md
@@ -2,48 +2,8 @@
 
 Spark is a powerful general cluster computing system for Big Data. We will be using DC/OS to deploy a Spark cluster.
 
-# Creating a Cluster
-
-We will use the Azure CLI 2.0 to quickly create an Azure Container Services cluster. Ensure you have the Azure CLI installed and have logged in.
-
-```
-az login
-```
-
-Next, we will create a resource group for the ACS cluster to be deployed.
-
-```
-az group create -n acs-dcos-spark-demo -l eastus
-```
-
-Now, we can create the cluster.
-
-```
-az acs create -n acs-dcos-spark-cluster -g acs-dcos-spark-demo -d acs-dcos-spark-dns --generate-ssh-keys
-```
-
-## Install the DC/OS CLI
-
-In order to manage this instance of ACS we will need the DC/OS cli,
-fortunately the Azure CLI makes it easy to install it.
-
-```
-az acs dcos install-cli
-```
-
-## Connect to the cluster
-
-To connect to the DC/OS masters in ACS we need to open an SSH tunnel:
-
-```
-ssh -fNL 80:localhost:80 -p 2200 azureuser@acs-dcos-spark-dnsmgmt.eastus.cloudapp.azure.com -i ~/.ssh/id_rsa
-```
-
-Now we tell the DC/OS CLI to use this tunnel to communicate with the cluster.
-
-```
-dcos config set core.dcos_url http://localhost
-```
+It is assumed that you have prepared the demo environment by running
+`prep.sh`, if not you need to break from this script and run it now.
 
 At this point, the DC/OS interface should be available at [https://localhost](https://localhost).
 

--- a/incubator/dcos_spark_install/script.md
+++ b/incubator/dcos_spark_install/script.md
@@ -12,7 +12,7 @@ At this point, the DC/OS interface should be available at [https://localhost](ht
 We can use the DC/OS cli to set up Spark.
 
 ```
-dcos package install spark
+dcos package install spark --yes
 ```
 
 *Note: you need to have virtualenv set up to install the Spark package (`sudo pip install virtualenv`).*
@@ -20,5 +20,5 @@ dcos package install spark
 Next, we can deploy Zeppelin.
 
 ```
-dcos install zeppelin
+dcos package install zeppelin --yes
 ```

--- a/incubator/dcos_spark_install/script.md
+++ b/incubator/dcos_spark_install/script.md
@@ -28,7 +28,7 @@ In order to manage this instance of ACS we will need the DC/OS cli,
 fortunately the Azure CLI makes it easy to install it.
 
 ```
-sudo az acs dcos install-cli
+az acs dcos install-cli
 ```
 
 ## Connect to the cluster
@@ -36,7 +36,7 @@ sudo az acs dcos install-cli
 To connect to the DC/OS masters in ACS we need to open an SSH tunnel:
 
 ```
-sudo ssh -fNL 80:localhost:80 -p 2200 azureuser@acs-dcos-spark-dnsmgmt.eastus.cloudapp.azure.com -i ~/.ssh/id_rsa
+ssh -fNL 80:localhost:80 -p 2200 azureuser@acs-dcos-spark-dnsmgmt.eastus.cloudapp.azure.com -i ~/.ssh/id_rsa
 ```
 
 Now we tell the DC/OS CLI to use this tunnel to communicate with the cluster.


### PR DESCRIPTION
Separate out prep and demo scripts
Provide some scripts to easily run the prep and demo scripts
improvements to the prep script

NOTE
The path to SimDem is currently hard coded in demo.sh and prep.sh - this needs to be resolved. Currently does not work with SimDem in a container which would be a better way of running.