### PR TITLE
Create the RG at the start

### DIFF
--- a/incubator/aci/create/script.md
+++ b/incubator/aci/create/script.md
@@ -6,16 +6,18 @@ Here we will create a single instance of a container using Azure Container Regis
 
 You must have installed the [Azure CLI](../../azure_compute/cli/install/).
 
-You will need to have created
-a [resource group](../../azure_compute/resource_group/create) in
-which to run your container instance.
-
 ## Environment Setup
 
 The current environment setup is:
 
 ```
 env | grep SIMDEM_.*
+```
+
+## Create the Resource Group
+
+```
+az group create --name $SIMDEM_RESOURCE_GROUP --location $SIMDEM_LOCATION
 ```
 
 ## Create the Container


### PR DESCRIPTION
If the "cleanup" script deletes the group, then the "demo" script should definitely create the group.  And creating a RG twice doesn't cause problems. (That I know of.)