### PR TITLE
turn off fast fail in circle CI tests, this will ensure that we clean…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,4 +16,4 @@ jobs:
           name: run Kubernetes tests
           no_output_timeout: "30m"
           command: |
-            simdem -p ./kubernetes test
+            simdem -p ./kubernetes --fastfail false test


### PR DESCRIPTION
…up after failed tests and thuse subsequent test runs will have a pristine environment. It also allows us to see the totality of failing tests.